### PR TITLE
Fix proposto #1

### DIFF
--- a/password_verifier.py
+++ b/password_verifier.py
@@ -30,7 +30,7 @@ while True:
         valida = False
     
     # La password deve contenere almeno un carattere speciale: .,_-
-    if not re.search("[\,._-]+", pw):
+    if not re.search("[\.,_\-]+", pw):
         print("La password deve contenere almeno un carattere speciale: .,_-")
         valida = False
     


### PR DESCRIPTION
I caratteri . e - sono usati per la grammatica delle RegEx, e quindi necessitano escape con \